### PR TITLE
Update git:// to https://.gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "lain"]
 	path = lain
-	url = git://github.com/lcpz/lain.git
+	url = https://github.com/lcpz/lain.git
 
 [submodule "freedesktop"]
 	path = freedesktop
-	url = git://github.com/lcpz/awesome-freedesktop.git
+	url = https://github.com/lcpz/awesome-freedesktop.git


### PR DESCRIPTION
The issue lies in the inability to fetch submodules due to the use of the git:// protocol, which may be blocked or restricted in your environment.